### PR TITLE
Specify POD encoding

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -293,6 +293,10 @@ sub _get_path_of {
 1;
 __END__
 
+=pod
+
+=encoding utf8
+
 =head1 NAME
 
 Test::PostgreSQL - PostgreSQL runner for tests


### PR DESCRIPTION
Fixes the display of the utf8 copyright symbol.
