### PR TITLE
remove dependency on Time::Hires

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,6 @@ name 'Test-PostgreSQL';
 all_from 'lib/Test/PostgreSQL.pm';
 
 requires 'Class::Accessor::Lite';
-requires 'Time::HiRes';
 test_requires 'DBI';
 test_requires 'DBD::Pg';
 test_requires 'Test::SharedFork' => 0.06;

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -8,7 +8,6 @@ use Class::Accessor::Lite;
 use Cwd;
 use DBI;
 use File::Temp qw(tempdir);
-use Time::HiRes qw(nanosleep);
 use POSIX qw(SIGTERM SIGKILL WNOHANG setuid);
 
 our $VERSION = '1.05';
@@ -227,17 +226,17 @@ sub stop {
     $sig ||= SIGTERM;
 
     kill $sig, $self->pid;
-    my $timeout = 10 * 1000000000;
+    my $timeout = 10;
     while ($timeout > 0 and waitpid($self->pid, WNOHANG) <= 0) {
-        $timeout -= nanosleep(500000000);
+        $timeout -= sleep(1);
     }
 
     if ($timeout <= 0) {
         warn "Pg refused to die gracefully; killing it violently.\n";
         kill SIGKILL, $self->pid;
-        $timeout = 5 * 1000000000;
+        $timeout = 5;
         while ($timeout > 0 and waitpid($self->pid, WNOHANG) <= 0) {
-            $timeout -= nanosleep(500000000);
+            $timeout -= sleep(1);
         }
         if ($timeout <= 0) {
             warn "Pg really didn't die.. WTF?\n";


### PR DESCRIPTION
Time::HiRes::nanosleep is not supported on all platforms and the effect
of removal is to increase delay on shutdown by one second at most.

This is the first of a series of patches I hope to submit that will enable use of Test::PostgreSQL on Windows platforms.
