### PR TITLE
Increase portability in general and for Windows especially

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,8 @@ name 'Test-PostgreSQL';
 all_from 'lib/Test/PostgreSQL.pm';
 
 requires 'Class::Accessor::Lite';
+requires 'File::Spec';
+requires 'File::Which';
 test_requires 'DBI';
 test_requires 'DBD::Pg';
 test_requires 'Test::SharedFork' => 0.06;

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -5,9 +5,10 @@ use warnings;
 
 use 5.008;
 use Class::Accessor::Lite;
-use Cwd;
 use DBI;
-use File::Temp qw(tempdir);
+use File::Spec;
+use File::Temp;
+use File::Which;
 use POSIX qw(SIGTERM SIGKILL WNOHANG setuid);
 
 our $VERSION = '1.06';
@@ -16,7 +17,6 @@ our $VERSION = '1.06';
 # in which case take the highest version. We append /bin/ and so forth to the path later.
 # Note that these are used only if the program isn't already in the path.
 our @SEARCH_PATHS = (
-    split(/:/, $ENV{PATH}),
     # popular installation dir?
     qw(/usr/local/pgsql),
     # ubuntu (maybe debian as well, find the newest version)
@@ -43,6 +43,7 @@ our %Defaults = (
     base_dir        => undef,
     initdb          => undef,
     initdb_args     => '-U postgres -A trust',
+    pg_ctl          => undef,
     pid             => undef,
     port            => undef,
     postmaster      => undef,
@@ -60,19 +61,21 @@ sub new {
         @_ == 1 ? %{$_[0]} : @_,
         _owner_pid => $$,
     }, $klass;
-    if (! defined $self->uid && $ENV{USER} eq 'root') {
+    if (! defined $self->uid && $ENV{USER} && $ENV{USER} eq 'root') {
         my @a = getpwnam('nobody')
             or die "user nobody does not exist, use uid() to specify user:$!";
         $self->uid($a[2]);
     }
     if (defined $self->base_dir) {
-        $self->base_dir(cwd . '/' . $self->base_dir)
-            if $self->base_dir !~ m|^/|;
+        $self->base_dir( File::Spec->rel2abs( $self->base_dir ) );
     } else {
         $self->base_dir(
-            tempdir(
+            File::Temp::newdir(
+                'temp.XXXX',
                 CLEANUP => $ENV{TEST_POSTGRESQL_PRESERVE} ? undef : 1,
-            ),
+                EXLOCK  => 0,
+                TMPDIR  => 1
+            )
         );
         chown $self->uid, -1, $self->base_dir
             if defined $self->uid;
@@ -82,8 +85,13 @@ sub new {
             or return;
         $self->initdb($prog);
     }
+    if (! defined $self->pg_ctl) {
+        my $prog = _find_program('pg_ctl')
+            or return;
+        $self->pg_ctl($prog);
+    }
     if (! defined $self->postmaster) {
-        my $prog = _find_program('postmaster')
+        my $prog = _find_program('postgres') || _find_program('postmaster')
             or return;
         $self->postmaster($prog);
     }
@@ -177,81 +185,115 @@ sub start {
 
 sub _try_start {
     my ($self, $port) = @_;
-    # open log and fork
-    open my $logfh, '>>', $self->base_dir . '/postgres.log'
-        or die 'failed to create log file:' . $self->base_dir
-            . "/postgres.log:$!";
-    my $pid = fork;
-    die "fork(2) failed:$!"
-        unless defined $pid;
-    if ($pid == 0) {
-        open STDOUT, '>>&', $logfh
-            or die "dup(2) failed:$!";
-        open STDERR, '>>&', $logfh
-            or die "dup(2) failed:$!";
-        chdir $self->base_dir
-            or die "failed to chdir to:" . $self->base_dir . ":$!";
-        if (defined $self->uid) {
-            setuid($self->uid)
-                or die "setuid failed:$!";
-        }
-        my $cmd = join(
-            ' ',
-            $self->postmaster,
-            $self->postmaster_args,
-            '-p', $port,
-            '-D', $self->base_dir . '/data',
-            '-k', $self->base_dir . '/tmp',
+    my $logfile = File::Spec->catfile($self->base_dir, 'postgres.log');
+    if ( $self->pg_ctl ) {
+
+        my @cmd = (
+            $self->pg_ctl,
+            'start', '-w', '-s', '-D',
+            File::Spec->catdir( $self->base_dir, 'data' ),
+            '-l', $logfile, '-o',
+            join( ' ',
+                $self->postmaster_args, '-p',
+                $port,                  '-k',
+                File::Spec->catdir( $self->base_dir, 'tmp' ) )
         );
-        exec($cmd);
-        die "failed to launch postmaster:$?";
-    }
-    close $logfh;
-    # wait until server becomes ready (or dies)
-    for (my $i = 0; $i < 100; $i++) {
-        open $logfh, '<', $self->base_dir . '/postgres.log'
-            or die 'failed to open log file:' . $self->base_dir
-                . "/postgres.log:$!";
-        my $lines = do { join '', <$logfh> };
-        close $logfh;
-        last
-            if $lines =~ /is ready to accept connections/;
-        if (waitpid($pid, WNOHANG) > 0) {
-            # failed
-            return $lines;
+
+        system(@cmd);
+        my $ret = open( my $pidfh, '<',
+            File::Spec->catfile( $self->base_dir, 'data', 'postmaster.pid' ) );
+
+        if ($ret) {
+            my $pid = do { local $/; <$pidfh> };
+            $self->pid($pid);
         }
-        sleep 1;
+        $self->port($port);
     }
-    # PostgreSQL is ready
-    $self->pid($pid);
-    $self->port($port);
+    else {
+        # old style - open log and fork
+        open my $logfh, '>>', $logfile
+            or die "failed to create log file: $logfile: $!";
+        my $pid = fork;
+        die "fork(2) failed:$!"
+            unless defined $pid;
+        if ($pid == 0) {
+            open STDOUT, '>>&', $logfh
+                or die "dup(2) failed:$!";
+            open STDERR, '>>&', $logfh
+                or die "dup(2) failed:$!";
+            chdir $self->base_dir
+                or die "failed to chdir to:" . $self->base_dir . ":$!";
+            if (defined $self->uid) {
+                setuid($self->uid)
+                    or die "setuid failed:$!";
+            }
+            my $cmd = join(
+                ' ',
+                $self->postmaster,
+                $self->postmaster_args,
+                '-p', $port,
+                '-D', File::Spec->catdir($self->base_dir, 'data'),
+                '-k', File::Spec->catdir($self->base_dir, 'tmp'),
+            );
+            exec($cmd);
+            die "failed to launch postmaster:$?";
+        }
+        close $logfh;
+        # wait until server becomes ready (or dies)
+        for (my $i = 0; $i < 100; $i++) {
+            open $logfh, '<', $logfile
+            or die "failed to create log file: $logfile: $!";
+            my $lines = do { join '', <$logfh> };
+            close $logfh;
+            last
+                if $lines =~ /is ready to accept connections/;
+            if (waitpid($pid, WNOHANG) > 0) {
+                # failed
+                return $lines;
+            }
+            sleep 1;
+        }
+        # PostgreSQL is ready
+        $self->pid($pid);
+        $self->port($port);
+    }   
     return;
 }
 
 sub stop {
     my ($self, $sig) = @_;
-    return unless defined $self->pid;
-
-    $sig ||= SIGTERM;
-
-    kill $sig, $self->pid;
-    my $timeout = 10;
-    while ($timeout > 0 and waitpid($self->pid, WNOHANG) <= 0) {
-        $timeout -= sleep(1);
+    if ( $self->pg_ctl ) {
+        my @cmd = (
+            $self->pg_ctl, 'stop', '-s', '-D',
+            File::Spec->catdir( $self->base_dir, 'data' ),
+            '-m', 'fast'
+        );
+        system(@cmd);
     }
+    else {
+        # old style
+        return unless defined $self->pid;
 
-    if ($timeout <= 0) {
-        warn "Pg refused to die gracefully; killing it violently.\n";
-        kill SIGKILL, $self->pid;
-        $timeout = 5;
+        $sig ||= SIGTERM;
+    
+        kill $sig, $self->pid;
+        my $timeout = 10;
         while ($timeout > 0 and waitpid($self->pid, WNOHANG) <= 0) {
             $timeout -= sleep(1);
         }
+
         if ($timeout <= 0) {
-            warn "Pg really didn't die.. WTF?\n";
+            warn "Pg refused to die gracefully; killing it violently.\n";
+            kill SIGKILL, $self->pid;
+            $timeout = 5;
+            while ($timeout > 0 and waitpid($self->pid, WNOHANG) <= 0) {
+                $timeout -= sleep(1);
+            }
+            if ($timeout <= 0) {
+                warn "Pg really didn't die.. WTF?\n";
+            }
         }
     }
-
     $self->pid(undef);
     return;
 }
@@ -262,64 +304,82 @@ sub setup {
     mkdir $self->base_dir;
     chmod 0755, $self->base_dir
         or die "failed to chmod 0755 dir:" . $self->base_dir . ":$!";
-    if ($ENV{USER} eq 'root') {
+    if ($ENV{USER} && $ENV{USER} eq 'root') {
         chown $self->uid, -1, $self->base_dir
             or die "failed to chown dir:" . $self->base_dir . ":$!";
     }
-    if (mkdir $self->base_dir . '/tmp') {
+    my $tmpdir = File::Spec->catfile($self->base_dir, 'tmp');
+    if (mkdir $tmpdir) {
         if ($self->uid) {
-            chown $self->uid, -1, $self->base_dir . '/tmp'
-                or die "failed to chown dir:" . $self->base_dir . "/tmp:$!";
+            chown $self->uid, -1, $tmpdir
+                or die "failed to chown dir:$tmpdir:$!";
         }
     }
     # initdb
-    if (! -d $self->base_dir . '/data') {
-        pipe my $rfh, my $wfh
-            or die "failed to create pipe:$!";
-        my $pid = fork;
-        die "fork failed:$!"
-            unless defined $pid;
-        if ($pid == 0) {
-            close $rfh;
-            open STDOUT, '>&', $wfh
-                or die "dup(2) failed:$!";
-            open STDERR, '>&', $wfh
-                or die "dup(2) failed:$!";
-            chdir $self->base_dir
-                or die "failed to chdir to:" . $self->base_dir . ":$!";
-            if (defined $self->uid) {
-                setuid($self->uid)
-                    or die "setuid failed:$!";
-            }
-            my $cmd = join(
-                ' ',
-                $self->initdb,
+    if (! -d File::Spec->catdir($self->base_dir, 'data')) {
+        if ( $self->pg_ctl ) {
+            my @cmd = (
+                $self->pg_ctl,
+                'init',
+                '-s',
+                '-D', File::Spec->catdir($self->base_dir, 'data'),
+                '-o',
                 $self->initdb_args,
-                '-D', $self->base_dir . '/data',
             );
-            exec($cmd);
-            die "failed to exec:$cmd:$!";
+            system(@cmd);
         }
-        close $wfh;
-        my $output = '';
-        while (my $l = <$rfh>) {
-            $output .= $l;
-        }
-        close $rfh;
-        while (waitpid($pid, 0) <= 0) {
-        }
-        die "*** initdb failed ***\n$output\n"
-            if $? != 0;
+        else {
+            # old style
+            pipe my $rfh, my $wfh
+                or die "failed to create pipe:$!";
+            my $pid = fork;
+            die "fork failed:$!"
+                unless defined $pid;
+            if ($pid == 0) {
+                close $rfh;
+                open STDOUT, '>&', $wfh
+                    or die "dup(2) failed:$!";
+                open STDERR, '>&', $wfh
+                    or die "dup(2) failed:$!";
+                chdir $self->base_dir
+                    or die "failed to chdir to:" . $self->base_dir . ":$!";
+                if (defined $self->uid) {
+                    setuid($self->uid)
+                        or die "setuid failed:$!";
+                }
+                my $cmd = join(
+                    ' ',
+                    $self->initdb,
+                    $self->initdb_args,
+                    '-D', File::Spec->catdir($self->base_dir, 'data'),
+                );
+                exec($cmd);
+                die "failed to exec:$cmd:$!";
+            }
+            close $wfh;
+            my $output = '';
+            while (my $l = <$rfh>) {
+                $output .= $l;
+            }
+            close $rfh;
+            while (waitpid($pid, 0) <= 0) {
+            }
+            die "*** initdb failed ***\n$output\n"
+                if $? != 0;
 
+        }
         # use postgres hard-coded configuration as some packagers mess
         # around with postgresql.conf.sample too much:
-        truncate $self->base_dir . '/data/postgresql.conf', 0;
+        truncate File::Spec->catfile( $self->base_dir, 'data',
+            'postgresql.conf' ), 0;
     }
 }
 
 sub _find_program {
     my $prog = shift;
     undef $errstr;
+    my $path = which $prog;
+    return $path if $path;
     for my $sp (@SEARCH_PATHS) {
         return "$sp/bin/$prog" if -x "$sp/bin/$prog";
         return "$sp/$prog" if -x "$sp/$prog";


### PR DESCRIPTION
Finally got round to making this work under Windows. Lots of changes but on the whole I've tried to make sure that old pg that might not have pg_ctl will still just work using old code paths which have received minimal changes. Main thing was to remove fork/pipe, make finding files easier under Windows, use File::Spec to build paths. Here a more complete list:

- new pg_ctl method which if defined does things the PostgreSQL way
  using pg_ctl to control init/start/stop
- use File::Spec->cat{dir|file} for path construction
- use File::Which for finding binaries in $ENV{PATH} rather than by
  splitting path and checking individually. This makes finding files
  on Windows much simpler.
- check whether $ENV{USER} is defined before trying comparison
- use File::Spec->rel2abs instead of manual method for
  checking/construction absolute paths
- add EXLOCK and TMPDIR to File::Temp::newdir (previously tempdir)
- pg_ctl way of doing things is attempted if pg_ctl is found otherwise
  old code paths are used
- look for postgres as well as postmaster since postmaster is deprecated
- pid is probably not used in pg_ctl mode but gets set anyway

Annoying things...

Failure to start pg results in this output in stderr:

 pg_ctl: could not start server
 Examine the log output.

I've only seen this in t/02-multi.t but it would be nice if it could be
lost somewhere. Maybe constructing pg_ctl commands as strings instead of
arrays so 2 could be sent to File::Spec->devnull - to be tried later.