### PR TITLE
localise $? in DESTROY closes rt#107957

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -110,6 +110,7 @@ sub new {
 }
 
 sub DESTROY {
+    local $?;
     my $self = shift;
     $self->stop
         if defined $self->pid && $$ == $self->_owner_pid;


### PR DESCRIPTION
From: https://metacpan.org/pod/distribution/perl/pod/perlobj.pod#Destructors

"Because DESTROY methods can be called at any time, you should localize
any global variables you might update in your DESTROY. In particular, if
you use eval {} you should localize $@, and if you use system or
backticks you should localize $?."