### PR TITLE
changes to help when stop is called during DESTROY rt#111181

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -10,7 +10,7 @@ use DBI;
 use File::Spec;
 use File::Temp;
 use File::Which;
-use POSIX qw(SIGTERM SIGKILL WNOHANG setuid);
+use POSIX qw(SIGQUIT SIGKILL WNOHANG setuid);
 
 our $VERSION = '1.20_03';
 our $errstr;
@@ -321,8 +321,8 @@ method _try_start($port) {
     return;
 }
 
-method stop($sig = SIGTERM) {
-    if ( $self->pg_ctl ) {
+method stop($sig = SIGQUIT) {
+    if ( $self->pg_ctl && defined $self->base_dir ) {
         my @cmd = (
             $self->pg_ctl, 'stop', '-s', '-D',
             File::Spec->catdir( $self->base_dir, 'data' ),
@@ -331,7 +331,7 @@ method stop($sig = SIGTERM) {
         system(@cmd) == 0 or die "@cmd failed:$?";
     }
     else {
-        # old style
+        # old style or $self->base_dir File::Temp obj already DESTROYed
         return unless defined $self->pid;
 
         kill $sig, $self->pid;


### PR DESCRIPTION
The problem:

If Test::PostgreSQL dies (external signal, etc) then `stop` gets called
from DESTROY. If using pg_ctl style control (Pg9+) and default
`base_dir` is used then order of destruction of the File::Temp object
and the Test::PostgreSQL object is unpredictable. If the File::Temp
object gets destroyed first then when `stop` gets called called during
DESTROY the `base_dir` attribute will be undefined and so using pg_ctl
to shutdown the database will fail.

The solution:

In `stop` don't use pg_ctl for shutdown if `base_dir` is undefined and
instead shutdown Pg using a signal as per non-pg_ctl control (Pg<9).

One additional change is to switch the default signal sent to Pg from
SIGTERM to SIGQUIT.

See http://www.postgresql.org/docs/9.5/static/server-shutdown.html for
details of the different signals. This should make Pg shutdown faster
and matches the `stop` mode of shutdown used by pg_ctl.

Many thanks to Peter Sergeant (SARGIE) for spotting this issue and for
his help explaining the situation.