### PR TITLE
add backwards-compatibility code for deprecated global %Defaults

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ requires 'Function::Parameters';
 requires 'Types::Standard';
 requires 'Moo';
 requires 'POSIX';
+requires 'Tie::Hash::Method';
 test_requires 'DBD::Pg';
 test_requires 'Test::SharedFork' => 0.06;
 


### PR DESCRIPTION
The %Defaults package global is now tied using Tie::Hash::Method
and warns on FETCH so any package which uses Test::PostgreSQL and reads
anything from %Defaults will see the deprecation warning.