### PR TITLE
Add parentheses to all method keywords

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -106,7 +106,7 @@ has initdb_args => (
   isa => Str,
 );
 
-method _build_initdb_args {
+method _build_initdb_args() {
     return "-U postgres -A trust " . $self->extra_initdb_args;
 }
 
@@ -175,7 +175,7 @@ has postmaster_args => (
   isa => Str,
 );
 
-method _build_postmaster_args {
+method _build_postmaster_args() {
     return "-h 127.0.0.1 -F " . $self->extra_postmaster_args;
 }
 


### PR DESCRIPTION
The latest release of Function::Parameters is more strict about the
method keyword and complains loudly if the character following
`method foo` isn't `()`. As such, I've updated the two methods that
were missing parentheses.