### PR TITLE
Add support for socket-only connections to the testing PostgreSQL

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -731,9 +731,9 @@ Setups the PostgreSQL instance.
 
 =head2 use_socket
 
-Whether to only connect via sockets; if false (the default),
+Whether to only connect via UNIX sockets; if false (the default),
 connections can occur via localhost. [This changes the L</dsn>
-returned to only give the socket directory, and avoids any issues with
+returned to only give the UNIX socket directory, and avoids any issues with
 conflicting TCP ports on localhost.]
 
 =head1 ENVIRONMENT

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -123,7 +123,7 @@ has extra_initdb_args => (
   default => "",
 );
 
-has use_socket => (
+has unix_socket => (
   is  => "ro",
   isa     => Bool,
   default => 0,
@@ -164,7 +164,7 @@ has psql_args => (
 
 method _build_psql_args() {
     return '-U postgres -d test -h '.
-        ($self->use_socket ? $self->socket_dir : '127.0.0.1') .
+        ($self->unix_socket ? $self->socket_dir : '127.0.0.1') .
         ' -p ' . $self->port
         . $self->extra_psql_args;
 }
@@ -215,7 +215,7 @@ has postmaster_args => (
 
 method _build_postmaster_args() {
     return "-h ".
-        ($self->use_socket ? "''" : "127.0.0.1") .
+        ($self->unix_socket ? "''" : "127.0.0.1") .
         " -F " . $self->extra_postmaster_args;
 }
 
@@ -279,7 +279,7 @@ sub _default_args {
     my ($self, %args) = @_;
     # If we're doing socket-only (IE, not listening on localhost),
     # then provide the path to the socket
-    if ($self->{use_socket}) {
+    if ($self->{unix_socket}) {
         $args{host} //= $self->socket_dir;
     } else {
         $args{host} ||= '127.0.0.1';
@@ -729,7 +729,7 @@ Stops postmaster.
 
 Setups the PostgreSQL instance.
 
-=head2 use_socket
+=head2 unix_socket
 
 Whether to only connect via UNIX sockets; if false (the default),
 connections can occur via localhost. [This changes the L</dsn>

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -94,12 +94,12 @@ has base_dir => (
   },
 );
 
-has socket_dir =>
-    (is => "ro",
-     isa => Str,
-     lazy => 1,
-     default => method () {File::Spec->catdir( $self->base_dir, 'tmp' )},
-    );
+has socket_dir => (
+  is => "ro",
+  isa => Str,
+  lazy => 1,
+  default => method () { File::Spec->catdir( $self->base_dir, 'tmp' ) },
+);
 
 has initdb => (
   is => "ro",
@@ -123,12 +123,11 @@ has extra_initdb_args => (
   default => "",
 );
 
-has use_socket =>
-    (
-     is  => "ro",
-     isa     => Bool,
-     default => 0,
-    );
+has use_socket => (
+  is  => "ro",
+  isa     => Bool,
+  default => 0,
+);
 
 has pg_ctl => (
   is => "ro",
@@ -165,7 +164,7 @@ has psql_args => (
 
 method _build_psql_args() {
     return '-U postgres -d test -h '.
-        ($self->use_socket?$self->socket_dir:'127.0.0.1').
+        ($self->use_socket ? $self->socket_dir : '127.0.0.1') .
         ' -p ' . $self->port
         . $self->extra_psql_args;
 }
@@ -216,7 +215,7 @@ has postmaster_args => (
 
 method _build_postmaster_args() {
     return "-h ".
-        ($self->use_socket?"''":"127.0.0.1").
+        ($self->use_socket ? "''" : "127.0.0.1") .
         " -F " . $self->extra_postmaster_args;
 }
 

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -730,6 +730,13 @@ Stops postmaster.
 
 Setups the PostgreSQL instance.
 
+=head2 use_socket
+
+Whether to only connect via sockets; if false (the default),
+connections can occur via localhost. [This changes the L</dsn>
+returned to only give the socket directory, and avoids any issues with
+conflicting TCP ports on localhost.]
+
 =head1 ENVIRONMENT
 
 =head2 POSTGRES_HOME

--- a/t/06-unix-socket.t
+++ b/t/06-unix-socket.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::PostgreSQL;
+use Try::Tiny;
+
+# if we can't connect normally, unix_socket failure isn't an issue.
+my $pgsql = try { Test::PostgreSQL->new }
+            catch { plan skip_all => $_ };
+
+undef $pgsql;
+
+plan tests => 2;
+
+ok($pgsql = Test::PostgreSQL->new(unix_socket => 1),
+   'connected using unix socket');
+
+my $dbh;
+
+ok($dbh = DBI->connect($pgsql->dsn), 'check if db is ready');
+$dbh->disconnect;
+
+undef $pgsql;


### PR DESCRIPTION
This merge requests adds support for UNIX socket-only connections to
the PostgreSQL testing instance. This is primarily useful because
you'd no longer have to try to find an open port on localhost, and
avoid any issues with port conflicts.

With `my $pgsql = Test::PostgreSQL->new(use_socket=>1);`,
`$pgsql->dsn` now returns a host which is the path to the socket
directory.

I've also abstracted out `socket_dir` so it's clearer what -k and -h
were specifying in the code. [I've tested it locally, and this seems
to work well.]