### PR TITLE
More features

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,3 @@
-MANIFEST			This list of files
 Changes
 inc/Module/Install.pm
 inc/Module/Install/Base.pm
@@ -10,13 +9,21 @@ inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
 lib/Test/PostgreSQL.pm
 Makefile.PL
-META.yml
+MANIFEST			This list of files
 META.json
+META.yml
 README.md
 t/00-base.t
 t/01-raii.t
 t/02-multi.t
 t/04-multiprocess.t
 t/05-recycle-base-dir.t
+t/06-unix-socket.t
+t/07-configs.t
+t/08-postgresql_conf.t
+t/09-run_psql.t
+t/10-seed_scripts.t
 t/deadlock.t
 t/pod.t
+t/seed/init.sql
+t/seed/seed.sql

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,4 +22,11 @@ repository 'https://github.com/TJC/Test-postgresql';
 
 license 'artistic_2';
 
+add_metadata x_contributors => [
+    'Toby Corkindale',
+    'Kazuho Oku',
+    'Peter Mottram',
+    'Alex Tokarev <tokarev@cpan.org>',
+];
+
 WriteAll;

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -33,6 +33,24 @@ tie our %Defaults, 'Tie::Hash::Method', FETCH => sub {
     postmaster_args => '-h 127.0.0.1 -F',
 );
 
+has dbname => (
+    is => 'ro',
+    isa => Str,
+    default => 'test',
+);
+
+has dbowner => (
+    is => 'ro',
+    isa => Str,
+    default => 'postgres',
+);
+
+has host => (
+    is => 'ro',
+    isa => Str,
+    default => '127.0.0.1',
+);
+
 # Various paths that Postgres gets installed under, sometimes with a version on the end,
 # in which case take the highest version. We append /bin/ and so forth to the path later.
 # *Note that these are used only if the program isn't already in the path!*
@@ -114,7 +132,7 @@ has initdb_args => (
 );
 
 method _build_initdb_args() {
-    return "-U postgres -A trust " . $self->extra_initdb_args;
+    return '-U '. $self->dbowner . ' -A trust ' . $self->extra_initdb_args;
 }
 
 has extra_initdb_args => (
@@ -163,7 +181,7 @@ has psql_args => (
 );
 
 method _build_psql_args() {
-    return '-U postgres -d test -h '.
+    return '-U ' . $self->dbowner . ' -d ' . $self->dbname . ' -h '.
         ($self->unix_socket ? $self->socket_dir : '127.0.0.1') .
         ' -p ' . $self->port
         . $self->extra_psql_args;
@@ -277,17 +295,17 @@ sub dsn {
 
 sub _default_args {
     my ($self, %args) = @_;
-    # If we're doing socket-only (IE, not listening on localhost),
+    # If we're doing socket-only (i.e., not listening on localhost),
     # then provide the path to the socket
     if ($self->{unix_socket}) {
         $args{host} //= $self->socket_dir;
     } else {
-        $args{host} ||= '127.0.0.1';
+        $args{host} ||= $self->host;
     }
 
     $args{port} ||= $self->port;
-    $args{user} ||= 'postgres';
-    $args{dbname} ||= 'test';
+    $args{user} ||= $self->dbowner;
+    $args{dbname} ||= $self->dbname;
     return %args;
 }
 
@@ -313,7 +331,7 @@ method start() {
     }
 
     # create "test" database
-    $self->_create_test_database;
+    $self->_create_test_database($self->dbname);
 }
 
 # This whole method was mostly cargo-culted from the earlier test-postgresql;
@@ -453,7 +471,7 @@ method stop($sig = SIGQUIT) {
     return;
 }
 
-method _create_test_database() {
+method _create_test_database($dbname) {
   my $tries = 5;
   my $dbh;
   while ($tries) {
@@ -476,8 +494,8 @@ method _create_test_database() {
   die "Connection to the database failed even after 5 tries"
       unless ($dbh);
 
-  if ($dbh->selectrow_arrayref(q{SELECT COUNT(*) FROM pg_database WHERE datname='test'})->[0] == 0) {
-      $dbh->do('CREATE DATABASE test')
+  if ($dbh->selectrow_arrayref(qq{SELECT COUNT(*) FROM pg_database WHERE datname='$dbname'})->[0] == 0) {
+      $dbh->do("CREATE DATABASE $dbname")
           or die $dbh->errstr;
   }
   return;
@@ -622,33 +640,50 @@ directory, and destroys it when the perl script exits.
 This module is a fork of Test::postgresql, which was abandoned by its author
 several years ago.
 
-=head1 FUNCTIONS
+=head1 ATTRIBUTES
 
-=head2 new
+C<Test::PostgreSQL> object has the following attributes:
 
-Create and run a PostgreSQL instance.  The instance is terminated when the
-returned object is being DESTROYed.  If required programs (initdb and
-postmaster) were not found, the function returns undef and sets appropriate
-message to $Test::PostgreSQL::errstr.
+=head2 dbname
+
+Database name to use in this C<Test::PostgreSQL> instance. Default is C<test>.
+
+=head2 dbowner
+
+Database owner user name. Default is C<postgres>.
+
+=head2 host
+
+Host name or IP address to use for PostgreSQL instance connections. Default is
+C<127.0.0.1>.
 
 =head2 base_dir
 
-Returns directory under which the PostgreSQL instance is being created.  The
-property can be set as a parameter of the C<new> function, in which case the
+Base directory under which the PostgreSQL instance is being created. The
+property can be passed as a parameter to the constructor, in which case the
 directory will not be removed at exit.
 
-=head2 initdb
+=head2 base_port
 
-=head2 postmaster
+Connection port number to start with. If the port is already used we will increment
+the value and try again.
 
-Path to C<initdb> and C<postmaster> which are part of the PostgreSQL
-distribution.  If not set, the programs are automatically searched by looking
-up $PATH and other prefixed directories. Since C<postmaster> is deprecated in
-newer PostgreSQL versions C<postgres> is used in preference to C<postmaster>.
+Default: C<15432>.
+
+=head2 unix_socket
+
+Whether to only connect via UNIX sockets; if false (the default),
+connections can occur via localhost. [This changes the L</dsn>
+returned to only give the UNIX socket directory, and avoids any issues with
+conflicting TCP ports on localhost.]
+
+=head2 socket_dir
+
+Unix socket directory to use if L</unix_socket> is true. Default is C<$basedir/tmp>.
 
 =head2 pg_ctl
 
-Path to C<pg_ctl> which is part of the PostgreSQL distribution.
+Path to C<pg_ctl> program which is part of the PostgreSQL distribution.
 
 Starting with PostgreSQL version 9.0 <pg_ctl> can be used to start/stop
 postgres without having to use fork/pipe and will be chosen automatically
@@ -657,21 +692,38 @@ enough.
 
 B<NOTE:> do NOT use this with PostgreSQL versions prior to version 9.0.
 
+By default we will try to find C<pg_ctl> in PostgresSQL directory.
+
+=head2 initdb
+
+Path to C<initdb> program which is part of the PostreSQL distribution. Default is
+to try and find it in PostgreSQL directory.
+
 =head2 initdb_args
 
-Defaults to C<-U postgres -A trust>
+Arguments to pass to C<initdb> program when creating a new PostgreSQL database
+cluster for Test::PostgreSQL session.
+
+Defaults to C<-U $db_owner -A trust>. See L</db_owner>.
 
 =head2 extra_initdb_args
 
-Extra args to be appended to L</initdb_args>
+Extra args to be appended to L</initdb_args>. Default is empty.
+
+=head2 postmaster
+
+Path to C<postmaster> which is part of the PostgreSQL distribution. If not set,
+the programs are automatically searched by looking up $PATH and other prefixed
+directories. Since C<postmaster> is deprecated in newer PostgreSQL versions
+C<postgres> is used in preference to C<postmaster>.
 
 =head2 postmaster_args
 
-Defaults to C<-h 127.0.0.1 -F>
+Defaults to C<-h 127.0.0.1 -F>.
 
 =head2 extra_postmaster_args
 
-Extra args to be appended to L</postmaster_args>
+Extra args to be appended to L</postmaster_args>. Default is empty.
 
 =head2 psql
 
@@ -690,23 +742,36 @@ by L</new>:
 =head2 psql_args
 
 Command line arguments necessary for C<psql> to connect to the correct PostgreSQL
-instance. Defaults to C<-U postgres -d test -h 127.0.0.1 -p $self->port>
+instance.
+
+Defaults to C<-U postgres -d test -h 127.0.0.1 -p $self->port>.
+
+See also L</db_owner>, L</dbname>, L</host>, L</base_port>.
 
 =head2 extra_psql_args
 
 Extra args to be appended to L</psql_args>.
 
+=head1 METHODS
+
+=head2 new
+
+Create and run a PostgreSQL instance. The instance is terminated when the
+returned object is being DESTROYed.  If required programs (initdb and
+postmaster) were not found, the function returns undef and sets appropriate
+message to $Test::PostgreSQL::errstr.
+
 =head2 dsn
 
 Builds and returns dsn by using given parameters (if any).  Default username is
-'postgres', and dbname is 'test' (an empty database).
+C<postgres>, and dbname is C<test> (an empty database).
 
 =head2 uri
 
 Builds and returns a connection URI using the given parameters (if any). See
 L<URI::db> for details about the format.
 
-Default username is 'postgres', and dbname is 'test' (an empty database).
+Default username is C<postgres>, and dbname is C<test> (an empty database).
 
 =head2 pid
 
@@ -729,13 +794,6 @@ Stops postmaster.
 
 Setups the PostgreSQL instance.
 
-=head2 unix_socket
-
-Whether to only connect via UNIX sockets; if false (the default),
-connections can occur via localhost. [This changes the L</dsn>
-returned to only give the UNIX socket directory, and avoids any issues with
-conflicting TCP ports on localhost.]
-
 =head1 ENVIRONMENT
 
 =head2 POSTGRES_HOME
@@ -744,7 +802,7 @@ If your postgres installation is not located in a well known path, or you have
 many versions installed and want to run your tests against particular one, set
 this environment variable to the desired path. For example:
 
- export POSTGRES_HOME='/usr/local/pgsql94beta'
+    export POSTGRES_HOME='/usr/local/pgsql94beta'
 
 This is the same idea and variable name which is used by the installer of
 L<DBD::Pg>.

--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -753,6 +753,27 @@ See also L</db_owner>, L</dbname>, L</host>, L</base_port>.
 
 Extra args to be appended to L</psql_args>.
 
+=head2 auto_start
+
+Integer value that controls whether PostgreSQL server is started and setup
+after creating C<Test::PostgreSQL> instance. Possible values:
+
+=over 4
+
+=item 0
+
+Do not start PostgreSQL.
+
+=item 1
+
+Start PostgreSQL but do not run L</setup>.
+
+=item 2
+
+Start PostgreSQL and run L</setup>.
+
+Default is C<2>.
+
 =head1 METHODS
 
 =head2 new

--- a/t/07-configs.t
+++ b/t/07-configs.t
@@ -1,0 +1,54 @@
+use Test::More tests => 7;
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::PostgreSQL;
+
+my $pgsql = Test::PostgreSQL->new(
+    dbname => 'foo',
+    dbowner => 'foobaroo',
+    host => 'localhost',
+);
+
+ok defined $pgsql, "test instance with non-default configs";
+
+my $have_dsn = $pgsql->dsn;
+
+my $default_dsn = q|DBI:Pg:dbname=test;host=127.0.0.1;port=| .
+                   $pgsql->port . q|;user=postgres|;
+
+my $want_dsn = q|DBI:Pg:dbname=foo;host=localhost;port=| .
+               $pgsql->port . q|;user=foobaroo|;
+
+is $have_dsn, $want_dsn, "non-default configs DSN";
+
+my $dbh = DBI->connect($want_dsn);
+my $ping = eval { $dbh->ping };
+
+is $@, '', "dbh ping no exception: $@";
+ok $ping, "non-default configs can connect to DSN";
+
+undef $dbh;
+
+# Should not connect with default configs
+$dbh = DBI->connect($default_dsn, undef, undef, { PrintError => 0 });
+
+ok !defined($dbh), "non-default configs can't connect to default DSN";
+
+my $pid = $pgsql->pid;
+
+ok kill(0, $pid), "test Postgres instance is alive";
+
+undef $pgsql;
+
+# Give it 5 seconds to shut down (usually overkill)
+my $watchdog = 50;
+
+while ( kill 0, $pid and $watchdog-- ) {
+    note "waiting, $watchdog";
+    select undef, undef, undef, 0.1;
+}
+
+ok !kill(0, $pid), "test Postgres instance stopped";

--- a/t/07-configs.t
+++ b/t/07-configs.t
@@ -1,16 +1,22 @@
-use Test::More tests => 7;
+use Test::More;
 
 use strict;
 use warnings;
 
 use DBI;
 use Test::PostgreSQL;
+use Try::Tiny;
 
-my $pgsql = Test::PostgreSQL->new(
-    dbname => 'foo',
-    dbowner => 'foobaroo',
-    host => 'localhost',
-);
+my $pgsql = try {
+    Test::PostgreSQL->new(
+        dbname => 'foo',
+        dbowner => 'foobaroo',
+        host => 'localhost',
+    )
+}
+catch { plan skip_all => $_ };
+
+plan tests => 7;
 
 ok defined $pgsql, "test instance with non-default configs";
 
@@ -47,7 +53,6 @@ undef $pgsql;
 my $watchdog = 50;
 
 while ( kill 0, $pid and $watchdog-- ) {
-    note "waiting, $watchdog";
     select undef, undef, undef, 0.1;
 }
 

--- a/t/08-postgresql_conf.t
+++ b/t/08-postgresql_conf.t
@@ -1,0 +1,46 @@
+use Test::More tests => 4;
+
+use strict;
+use warnings;
+
+use File::Spec;
+use Test::PostgreSQL;
+
+my $pg = Test::PostgreSQL->new();
+
+ok defined($pg), "test instance 1 created";
+
+my $conf_file = File::Spec->catfile(
+    $pg->base_dir, 'data', 'postgresql.conf'
+);
+
+# By default postgresql.conf is truncated
+is -s $conf_file, 0, "test 1 postgresql.conf size 0";
+
+undef $pg;
+
+$pg = Test::PostgreSQL->new(
+    pg_config => <<'EOC',
+# foo baroo mymse throbbozongo
+fsync = off
+synchronous_commit = off
+full_page_writes = off
+bgwriter_lru_maxpages = 0
+shared_buffers = 512MB
+effective_cache_size = 512MB
+work_mem = 100MB
+EOC
+);
+
+ok defined($pg), "test instance 2 created";
+
+$conf_file = File::Spec->catfile(
+    $pg->base_dir, 'data', 'postgresql.conf'
+);
+
+open my $fh, '<', $conf_file;
+my $pg_conf = <$fh>;
+close $fh;
+
+like $pg_conf, qr/foo baroo mymse throbbozongo/,
+    "test instance 2 postgresql.conf match";

--- a/t/08-postgresql_conf.t
+++ b/t/08-postgresql_conf.t
@@ -1,27 +1,43 @@
-use Test::More tests => 4;
+use Test::More;
 
 use strict;
 use warnings;
 
+use DBI;
 use File::Spec;
 use Test::PostgreSQL;
+use Try::Tiny;
 
-my $pg = Test::PostgreSQL->new();
+my $pg = try { Test::PostgreSQL->new() }
+         catch { plan skip_all => $_ };
+
+plan tests => 8;
 
 ok defined($pg), "test instance 1 created";
 
-my $conf_file = File::Spec->catfile(
-    $pg->base_dir, 'data', 'postgresql.conf'
-);
+my $datadir = File::Spec->catfile($pg->base_dir, 'data');
+my $conf_file = File::Spec->catfile($datadir, 'postgresql.conf');
 
 # By default postgresql.conf is truncated
 is -s $conf_file, 0, "test 1 postgresql.conf size 0";
 
+my $cmd = join ' ', (
+    $pg->postmaster,
+    '-D', $datadir,
+    '-C', 'synchronous_commit'
+);
+
+my $config_value = qx{$cmd};
+
+# Default for synchronous_commit is on
+like $config_value, qr/^on/, "test 1 synchronous_commit = on";
+
+my @pids = ($pg->pid);
+
 undef $pg;
 
 $pg = Test::PostgreSQL->new(
-    pg_config => <<'EOC',
-# foo baroo mymse throbbozongo
+    pg_config => q|# foo baroo mymse throbbozongo
 fsync = off
 synchronous_commit = off
 full_page_writes = off
@@ -29,18 +45,45 @@ bgwriter_lru_maxpages = 0
 shared_buffers = 512MB
 effective_cache_size = 512MB
 work_mem = 100MB
-EOC
-);
+|);
 
 ok defined($pg), "test instance 2 created";
 
-$conf_file = File::Spec->catfile(
-    $pg->base_dir, 'data', 'postgresql.conf'
+my $dsn = $pg->dsn;
+my $dbh = DBI->connect($dsn, undef, undef, { PrintError => !1 });
+
+# Means config was correct
+ok defined($dbh), "test instance 2 connected";
+
+$datadir = File::Spec->catfile($pg->base_dir, 'data');
+$conf_file = File::Spec->catfile($datadir, 'postgresql.conf');
+
+$cmd = join ' ', (
+    $pg->postmaster,
+    '-D', $datadir,
+    '-C', 'synchronous_commit'
 );
 
+$config_value = qx{$cmd};
+
+# Now it should be off (overridden above)
+like $config_value, qr/^off/, "test 2 synchronous_commit = off";
+
 open my $fh, '<', $conf_file;
-my $pg_conf = <$fh>;
+my $pg_conf = join '', <$fh>;
 close $fh;
 
 like $pg_conf, qr/foo baroo mymse throbbozongo/,
     "test instance 2 postgresql.conf match";
+
+push @pids, $pg->pid;
+
+undef $pg;
+
+my $watchdog = 50;
+
+while ( kill 0, @pids and $watchdog-- ) {
+    select undef, undef, undef, 0.1;
+}
+
+ok !kill(0, @pids), "test Postgres instances stopped";

--- a/t/09-run_psql.t
+++ b/t/09-run_psql.t
@@ -1,0 +1,30 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::PostgreSQL;
+use Try::Tiny;
+
+my $pg = try { Test::PostgreSQL->new() }
+         catch { plan skip_all => $_ };
+
+plan tests => 3;
+
+ok defined($pg), "new instance created";
+
+eval {
+    $pg->run_psql(
+        '-c', q|'CREATE TABLE foo (bar int)'|,
+        '-c', q|'INSERT INTO foo (bar) VALUES (42)'|,
+    )
+};
+
+is $@, '', "run_psql no exception" . ($@ ? ": $@" : "");
+
+
+my $dbh = DBI->connect($pg->dsn);
+my @row = $dbh->selectrow_array('SELECT * FROM foo');
+
+is_deeply \@row, [42], "seed values match";

--- a/t/10-seed_scripts.t
+++ b/t/10-seed_scripts.t
@@ -1,0 +1,30 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::PostgreSQL;
+use Try::Tiny;
+
+my $pg = try {
+    Test::PostgreSQL->new(
+        seed_scripts => [
+            't/seed/init.sql',
+            't/seed/seed.sql',
+        ],
+    );
+}
+catch {
+    plan skip_all => $_;
+};
+
+plan tests => 3;
+
+is $@, '', "new no exception" . ($@ ? ": $@" : "");
+ok defined($pg), "new instance created";
+
+my $dbh = DBI->connect($pg->dsn);
+my @row = $dbh->selectrow_array('SELECT * FROM foo');
+
+is_deeply \@row, [42], "seed values match";

--- a/t/seed/init.sql
+++ b/t/seed/init.sql
@@ -1,0 +1,3 @@
+CREATE TABLE foo (
+    bar int
+);

--- a/t/seed/seed.sql
+++ b/t/seed/seed.sql
@@ -1,0 +1,1 @@
+INSERT INTO foo (bar) VALUES (42);


### PR DESCRIPTION
Added more attributes/configuration options:

* dbname (default: `test`)
* dbowner (default: `postgres`)
* host (default: `127.0.0.1`)
* pg_config
* run_psql_args
* seed_scripts

Added methods:

* run_psql
* run_psql_scripts

The end goal is to have database seed scripts executed with `psql` automatically on `Test::PostgreSQL` startup instead of doing all that manually. Essentially this PR is about cleaning up stuff used in-house and merging it upstream.

Also beefed up the pod a bit, added tests.