### PR TITLE
Avoid test failures with psql < 9.6.

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -202,7 +202,7 @@ has run_psql_args => (
     is => 'ro',
     isa => Str,
     # Single transaction, skip .psqlrc, be quiet, echo errors, stop on first error
-    default => '-1Xqb -v ON_ERROR_STOP=1',
+    default => '-1Xq -v ON_ERROR_STOP=1',
 );
 
 has seed_scripts => (
@@ -613,12 +613,12 @@ method setup() {
 
 method _find_program($prog) {
     undef $errstr;
-    my $path = which $prog;
-    return $path if $path;
     for my $sp (@{$self->search_paths}) {
         return "$sp/bin/$prog" if -x "$sp/bin/$prog";
         return "$sp/$prog" if -x "$sp/$prog";
     }
+    my $path = which $prog;
+    return $path if $path;
     $errstr = "could not find $prog, please set appropriate PATH or POSTGRES_HOME";
     return;
 }

--- a/t/09-run_psql.t
+++ b/t/09-run_psql.t
@@ -14,10 +14,14 @@ plan tests => 3;
 
 ok defined($pg), "new instance created";
 
+my @stmts = (
+    q|CREATE TABLE foo (bar int)|,
+    q|INSERT INTO foo (bar) VALUES (42)|,
+);
 eval {
     $pg->run_psql(
-        '-c', q|'CREATE TABLE foo (bar int)'|,
-        '-c', q|'INSERT INTO foo (bar) VALUES (42)'|,
+        '-c',
+        q|'| . join( '; ', @stmts ) . q|'|,
     )
 };
 


### PR DESCRIPTION
* Make POSTGRES_HOME override PATH, so that an older psql in PATH
does not prevent use of a newer one.

* Avoid the -b switch to psql, as it is only supported on 9.5+ and
causes tests/install to fail on older versions.

* Pass multiple SQL command to psql as "-c '...; ...'" rather than
"-c '...' -c '...'", as psql < 9.6 does not appear to support multiple
instances of the -c switch, which breaks t/09-run_psql.t.