### PR TITLE
Allow using beta versions

### DIFF
--- a/lib/Test/PostgreSQL.pm
+++ b/lib/Test/PostgreSQL.pm
@@ -178,7 +178,7 @@ method _pg_ctl_builder() {
   if ( $prog ) {
       # we only use pg_ctl if Pg version is >= 9
       my $ret = qx/"$prog" --version/;
-      if ( $ret =~ /(\d+)(?:\.|devel)/ && $1 >= 9 ) {
+      if ( $ret =~ /(\d+)(?:\.|devel|beta)/ && $1 >= 9 ) {
           return $prog;
       }
       warn "pg_ctl version earlier than 9";


### PR DESCRIPTION
Simply changes the regex used to parse the version number for pg_ctl to allow beta versions too. fixes #38 